### PR TITLE
rename type to sip_type

### DIFF
--- a/sip-1/index.md
+++ b/sip-1/index.md
@@ -2,7 +2,7 @@
 sip: 1
 title: "[SIP1] SIP Purpose and Guidelines"
 author: Starcoin Core Dev
-type: Standards Track
+sip_type: Standards Track
 category: Core
 status: Beta
 created: 2020-11-01

--- a/sip-1/index.zh.md
+++ b/sip-1/index.zh.md
@@ -2,7 +2,7 @@
 sip: 1
 title: "[SIP1] SIP 提案指南"
 author: Starcoin Core Dev
-type: Standards Track
+sip_type: Standards Track
 category: Core
 status: Beta
 created: 2021-11-01

--- a/sip-2/index.md
+++ b/sip-2/index.md
@@ -2,7 +2,7 @@
 sip: 2
 title: "[SIP2] Technical paper"
 author: Starcoin Core Dev
-type: paper
+sip_type: paper
 category: Core
 status: Beta
 created: 2021-11-01

--- a/sip-2/index.zh.md
+++ b/sip-2/index.zh.md
@@ -2,7 +2,7 @@
 sip: 2
 title: "[SIP2] 技术白皮书"
 author: Starcoin Core Dev
-type: paper
+sip_type: paper
 category: Core
 status: Beta
 created: 2021-11-01

--- a/sip-20/index.md
+++ b/sip-20/index.md
@@ -2,7 +2,7 @@
 sip: 20
 title: "[SIP20] JSONRPC"
 author: "@lerencao"
-type: API
+sip_type: API
 category: API
 status: Alpha
 created: 2020-11-17

--- a/sip-20/index.zh.md
+++ b/sip-20/index.zh.md
@@ -2,7 +2,7 @@
 sip: 20
 title: "[SIP20] JSONRPC"
 author: "@lerencao"
-type: API
+sip_type: API
 category: API
 status: Alpha
 created: 2020-11-17

--- a/sip-21/index.md
+++ b/sip-21/index.md
@@ -2,7 +2,7 @@
 sip: 21
 title: "[SIP21] Receipt Identifier"
 author: "@lerencao"
-type: SDK
+sip_type: SDK
 category: SDK
 status: Alpha
 created: 2021-05-06

--- a/sip-21/index.zh.md
+++ b/sip-21/index.zh.md
@@ -2,7 +2,7 @@
 sip: 21
 title: "[SIP21] 收款识别码（Receipt Identifier）"
 author: "@lerencao"
-type: SDK
+sip_type: SDK
 category: SDK
 status: Alpha
 created: 2021-05-06

--- a/sip-3/index.md
+++ b/sip-3/index.md
@@ -2,7 +2,7 @@
 sip: 3
 title: "[SIP3] Token Economics"
 author: Starcoin Foundation
-type: paper
+sip_type: paper
 category: Core
 status: Beta
 created: 2020-11-14

--- a/sip-3/index.zh.md
+++ b/sip-3/index.zh.md
@@ -2,7 +2,7 @@
 sip: 3
 title: "[SIP3] 经济模型"
 author: Starcoin Foundation
-type: paper
+sip_type: paper
 category: Core
 status: Beta
 created: 2021-11-01

--- a/sip-4/index.md
+++ b/sip-4/index.md
@@ -2,7 +2,7 @@
 sip: 3
 title: "[SIP4] SIP as feature flag"
 author: Starcoin Core Dev
-type: paper
+sip_type: paper
 category: Core
 status: Beta
 created: 2021-11-01

--- a/sip-4/index.zh.md
+++ b/sip-4/index.zh.md
@@ -2,7 +2,7 @@
 sip: 3
 title: "[SIP4] SIP 作为特性开关"
 author: Starcoin Core Dev
-type: paper
+sip_type: paper
 category: Core
 status: Draft
 created: 2021-04-11

--- a/sip-5/index.md
+++ b/sip-5/index.md
@@ -2,7 +2,7 @@
 sip: 3
 title: "[SIP4] Introduce Treasury"
 author: "@jolestar"
-type: paper
+sip_type: paper
 category: Core
 status: Beta
 created: 2021-4-13

--- a/sip-5/index.zh.md
+++ b/sip-5/index.zh.md
@@ -2,7 +2,7 @@
 sip: 3
 title: "[SIP4] 引入国库机制，让链的发展可持续"
 author: "@jolestar"
-type: paper
+sip_type: paper
 category: Core
 status: Draft
 created: 2021-04-13


### PR DESCRIPTION
use `sip_type` to replace  `type` in document metadata, for avoid conflict with hugo.